### PR TITLE
Make setup.py Py3k- and PEP8-compliant.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ maxflow_module = Extension(
         "maxflow/src/core/maxflow.cpp",
         "maxflow/src/fastmin.cpp"
     ],
-    language="c++", include_dirs=[
+    language="c++",
+    include_dirs=[
         numpy_include_dir,
         "/usr/local/include"
     ]


### PR DESCRIPTION
Replaced the call to execfile (does not exist in Py3k) with runpy (introduced in Python 2.5). Also made some stylistic changes so that the file conforms to PEP8.
