### PR TITLE
don't return void

### DIFF
--- a/maxflow/src/_maxflow.pyx
+++ b/maxflow/src/_maxflow.pyx
@@ -457,13 +457,13 @@ cdef public class GraphInt [object PyObject_GraphInt, type GraphInt]:
         This option makes sense only if a small part of the graph is changed.
         The initialization procedure goes only through marked nodes then.
         """
-        return self.thisptr.mark_node(i)
+        self.thisptr.mark_node(i)
     def mark_grid_nodes(self, nodeids):
         """
         Mark nodes that have changed. This is equivalent to call ``mark_node``
         for many nodes.
         """
-        return self.thisptr.mark_grid_nodes(nodeids)
+        self.thisptr.mark_grid_nodes(nodeids)
     def get_segment(self, i):
         """Returns which segment the given node belongs to."""
         return self.thisptr.what_segment(i)
@@ -901,13 +901,13 @@ cdef public class GraphFloat [object PyObject_GraphFloat, type GraphFloat]:
         This option makes sense only if a small part of the graph is changed.
         The initialization procedure goes only through marked nodes then.
         """
-        return self.thisptr.mark_node(i)
+        self.thisptr.mark_node(i)
     def mark_grid_nodes(self, nodeids):
         """
         Mark nodes that have changed. This is equivalent to call ``mark_node``
         for many nodes.
         """
-        return self.thisptr.mark_grid_nodes(nodeids)
+        self.thisptr.mark_grid_nodes(nodeids)
     def get_segment(self, i):
         """Returns which segment the given node belongs to."""
         return self.thisptr.what_segment(i)


### PR DESCRIPTION
The methods `mark_node` and `mark_grid_nodes` return void.
This causes a problem when building in Raspbian, which uses older versions of the libraries (e.g., cython 0.21.1). The error message is: `Cannot convert 'void' to Python object`. The solution is to simply remove the `return` keyword in those methods.

PyMaxflow currently builds correctly on my Mac using cython 0.24