### PR TITLE
Fix link to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ the C++ library, PyMaxflow offers
   minimization which use the ``maxflow`` method: the αβ-swap
   and the α-expansion.
 
-Take a look at the `PyMaxflow documentation <http://pmneila.github.com/PyMaxflow/>`_.
+Take a look at the `PyMaxflow documentation <http://pmneila.github.io/PyMaxflow/>`_.
 
 Requirements
 ------------


### PR DESCRIPTION
GIthub pages [now uses `.io` TLD instead of `.com`.][1] The old link is broken.

[1]: https://github.blog/2013-04-05-new-github-pages-domain-github-io/