### PR TITLE
Restrict minimum necessary permissions for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/maxflow-ci.yml
+++ b/.github/workflows/maxflow-ci.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [master]
   pull_request:
+  
+# Added: Restrict minimum necessary permissions for GITHUB_TOKEN
+permissions:
+  contents: read  # Only allow reading repository content
+  actions: read   # Only allow reading workflow information
 
 jobs:
   test:

--- a/.github/workflows/maxflow-deployment.yml
+++ b/.github/workflows/maxflow-deployment.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags: 'v[0-9]+*'
 
+# Restrict minimum necessary permissions for GITHUB_TOKEN
+permissions:
+  contents: read  # Required for checking out repository code
+
 jobs:
   deploy-sdist:
     name: Deploy source distribution
@@ -18,13 +22,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - name: Install cibuildwheel
+      - name: Install build tools
         run: |
           python -m pip install --upgrade pip
           python -m pip install build
-      - name: Build sdist
+      - name: Build source distribution
         run: python -m build --sdist
-      - name: Deploy sdist
+      - name: Deploy to PyPI
         run: |
           python3 -m pip install twine
           python3 -m twine upload --skip-existing dist/*
@@ -55,7 +59,7 @@ jobs:
           python -m pip install cibuildwheel
       - name: Build wheels
         run: python3 -m cibuildwheel --output-dir wheelhouse
-      - name: Deploy
+      - name: Deploy wheels to PyPI
         run: |
           python3 -m pip install twine
           python3 -m twine upload --skip-existing wheelhouse/*.whl


### PR DESCRIPTION
In GitHub Actions, GITHUB_TOKEN is an automatically generated token used to interact with the GitHub repository in workflows (e.g., pulling code, triggering other workflows). By default, it may have broad permissions, such as read and write access to repository content and the ability to manipulate pull requests.
Meanwhile, "restricting to the minimum necessary permissions" is a security best practice: only assign the permissions that are essential for the normal operation of the workflow to GITHUB_TOKEN (e.g., only allowing read access to repository content), and remove all unnecessary permissions (such as write or delete access). This approach helps reduce security risks in case the token is misused, and aligns with the Principle of Least Privilege.